### PR TITLE
Use char instead of byte for text

### DIFF
--- a/Arduino/HT1632/HT1632.cpp
+++ b/Arduino/HT1632/HT1632.cpp
@@ -10,7 +10,7 @@
  * functions go here:
  */
 
-void HT1632Class::drawText(const byte text [], int x, int y, const byte font [], int font_end [], uint8_t font_height, uint8_t gutter_space) {
+void HT1632Class::drawText(const char text [], int x, int y, const byte font [], int font_end [], uint8_t font_height, uint8_t gutter_space) {
 	int curr_x = x;
 	char i = 0;
 	char currchar;
@@ -52,7 +52,7 @@ void HT1632Class::drawText(const byte text [], int x, int y, const byte font [],
 }
 
 // Gives you the width, in columns, of a particular string.
-int HT1632Class::getTextWidth(const byte text [], int font_end [], uint8_t font_height, uint8_t gutter_space) {
+int HT1632Class::getTextWidth(const char text [], int font_end [], uint8_t font_height, uint8_t gutter_space) {
 	int wd = 0;
 	char i = 0;
 	char currchar;

--- a/Arduino/HT1632/HT1632.h
+++ b/Arduino/HT1632/HT1632.h
@@ -157,8 +157,8 @@ class HT1632Class
     void transition(uint8_t mode, int time = 1000); // Time is in milliseconds.
     void clear();
     void drawImage(const byte img [], uint8_t width, uint8_t height, int8_t x, int8_t y, int offset = 0);
-    void drawText(const byte text [], int x, int y, const byte font [], int font_end [], uint8_t font_height, uint8_t gutter_space = 1);
-    int getTextWidth(const byte text [], int font_end [], uint8_t font_height, uint8_t gutter_space = 1);
+    void drawText(const char text [], int x, int y, const byte font [], int font_end [], uint8_t font_height, uint8_t gutter_space = 1);
+    int getTextWidth(const char text [], int font_end [], uint8_t font_height, uint8_t gutter_space = 1);
     void setBrightness(char brightness, char selectionmask = 0b00010000);
     
     void setPixel(uint8_t x, uint8_t y);


### PR DESCRIPTION
Most other libraries use `char` for text, and recent versions of Arduino IDE throw an error when attempting to convert between `byte` (which is seen as `unsigned char`) and `char`