### PR TITLE
Added scroll functionality.

### DIFF
--- a/Arduino/HT1632/HT1632.cpp
+++ b/Arduino/HT1632/HT1632.cpp
@@ -307,6 +307,17 @@ uint8_t HT1632Class::getPixel(uint8_t x, uint8_t y, uint8_t channel) {
 	return mem[channel][GET_ADDR_FROM_X_Y(x, y)] & GET_BIT_FROM_Y(y);
 }
 
+void HT1632Class::scrollLeft() {
+	for(uint8_t c=0; c<NUM_CHANNEL; c++) {
+		byte *to = &mem[c][GET_ADDR_FROM_X_Y(0, 0)];
+		byte *from = &mem[c][GET_ADDR_FROM_X_Y(1, 0)];
+
+		memmove(to, from, ADDR_SPACE_SIZE - 1);
+
+		mem[c][ADDR_SPACE_SIZE - 1] = 0x00;
+	}
+}
+
 void HT1632Class::fill() {
 	for(uint8_t i = 0; i < ADDR_SPACE_SIZE; ++i) {
 		mem[_tgtChannel][i] = 0xFF;

--- a/Arduino/HT1632/HT1632.h
+++ b/Arduino/HT1632/HT1632.h
@@ -183,6 +183,8 @@ class HT1632Class
     uint8_t getPixel(uint8_t x, uint8_t y, uint8_t channel);
     void fill();
     void fillAll();
+
+    void scrollLeft();
 };
 
 extern HT1632Class HT1632;


### PR DESCRIPTION
Added scrollLeft method which scrolls the all channels 1 pixel to the… left and inserts an empty-pixel add the right.

This implementation may not work with displays of an other w/h than 32x8; I only tested it with 32x8.