### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,28 +6,28 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-HT1632			KEYWORD1
+HT1632	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin			KEYWORD2
-sendCommand		KEYWORD2
+begin	KEYWORD2
+sendCommand	KEYWORD2
 renderTarget	KEYWORD2
 selectChannel	KEYWORD2
-render			KEYWORD2
-transition		KEYWORD2
-clear			KEYWORD2
-drawImage		KEYWORD2
-drawText		KEYWORD2
+render	KEYWORD2
+transition	KEYWORD2
+clear	KEYWORD2
+drawImage	KEYWORD2
+drawText	KEYWORD2
 getTextWidth	KEYWORD2
 setBrightness	KEYWORD2
-setCLK			KEYWORD2
+setCLK	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-COM_SIZE		LITERAL1
-OUT_SIZE		LITERAL1
+COM_SIZE	LITERAL1
+OUT_SIZE	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords